### PR TITLE
Normalized various permutations of Backblaze, fixed file numbering

### DIFF
--- a/Backblaze -- Step 1 -- File Processing.ipynb
+++ b/Backblaze -- Step 1 -- File Processing.ipynb
@@ -3,7 +3,7 @@
         {
             "cell_type": "markdown",
             "metadata": {},
-            "source": "# A Complete Solution to the BackBaze.com Kaggle Problem"
+            "source": "# A Complete Solution to the Backblaze Kaggle Problem"
         },
         {
             "cell_type": "markdown",
@@ -28,12 +28,12 @@
         {
             "cell_type": "markdown",
             "metadata": {},
-            "source": "BackBaze.com, you are the \"GOAT.\" You are the \"cat's meow.\" You \"Rock the House.\" In case you don't know why BackBaze.com is so totally \"kick-ass,\" they open-sourced a vast set of hard drive information a few years ago and continue updating it each quarter. What a treasure trove of superb data. BackBlaze.com, thank you from the bottom of my heart. \n\nThe backblaze.com data includes operational metrics from hard drives with an indicator of a hard-drive failure. It is an excellent source for teaching techniques related to machine failure. Again, thank you for making this available to the open-source community.\n\nHere is a link to the data.\n\n\nhttps://www.backblaze.com/b2/hard-drive-test-data.html\n\nMy goal in this series of articles is not to give the best solution with the highest AUC.  My goal is to show you how to approach equipment failure problems and build solutions that reflect realistic accuracy, and provide an easy transition from the lab to the real world. \n\nI will use a Spark/Python Jupyter notebook inside IBM's Watson Studio on the cloud as a tool in this discussion.\n\nhttps://www.ibm.com/cloud/watson-studio\n\nI will also be using cloud object storage on the IBM cloud.\n\nhttps://www.ibm.com/cloud/block-storage\n\n\nThe first article in this series is, without question, the most mundane.  I will be loading data from the CSV files provided by backblaze.com into SPARK data frames.  File processing is a tedious but necessary part of the process. "
+            "source": "Backblaze, you are the \"GOAT.\" You are the \"cat's meow.\" You \"Rock the House.\" In case you don't know why Backblaze is so totally \"kick-ass,\" they open-sourced a vast set of hard drive information a few years ago and continue updating it each quarter. What a treasure trove of superb data. Backblaze, thank you from the bottom of my heart. \n\nThe Backblaze data includes operational metrics from hard drives with an indicator of a hard-drive failure. It is an excellent source for teaching techniques related to machine failure. Again, thank you for making this available to the open-source community.\n\nHere is a link to the data.\n\n\nhttps://www.backblaze.com/b2/hard-drive-test-data.html\n\nMy goal in this series of articles is not to give the best solution with the highest AUC.  My goal is to show you how to approach equipment failure problems and build solutions that reflect realistic accuracy, and provide an easy transition from the lab to the real world. \n\nI will use a Spark/Python Jupyter notebook inside IBM's Watson Studio on the cloud as a tool in this discussion.\n\nhttps://www.ibm.com/cloud/watson-studio\n\nI will also be using cloud object storage on the IBM cloud.\n\nhttps://www.ibm.com/cloud/block-storage\n\n\nThe first article in this series is, without question, the most mundane.  I will be loading data from the CSV files provided by Backblaze into SPARK data frames.  File processing is a tedious but necessary part of the process. "
         },
         {
             "cell_type": "markdown",
             "metadata": {},
-            "source": "Before running this code, I downloaded the .csv files from BackBlaze.com and uploaded them to IBM Cloud object storage. Note our friends at backblaze.com conveniently labeled the CSV files in the following format. \n\n\"YYYY_MM_DD.csv.\"\n\n The naming convention makes it easy to load them systematically from cloud object storage to spark data frames. Also, note that I only use a handful of the fields in the CSV file. And finally, I limited my work here to 2018, 2019, and 2020.\n \n I created these notebooks with a runtime useing 1 driver with 1 vCPU and 4 GB RAM, and 2 executors each with 1 vCPU and 4 GB RAM.  This is available for free on the IBM Cloud.  Some of the notebooks take a few hours to run.  You'll need to schedule your notebooks to run as jobs.\n \n https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/schedule-task.html"
+            "source": "Before running this code, I downloaded the .csv files from Backblaze and uploaded them to IBM Cloud object storage. Note our friends at Backblaze conveniently labeled the CSV files in the following format. \n\n\"YYYY_MM_DD.csv.\"\n\n The naming convention makes it easy to load them systematically from cloud object storage to spark data frames. Also, note that I only use a handful of the fields in the CSV file. And finally, I limited my work here to 2018, 2019, and 2020.\n \n I created these notebooks with a runtime useing 1 driver with 1 vCPU and 4 GB RAM, and 2 executors each with 1 vCPU and 4 GB RAM.  This is available for free on the IBM Cloud.  Some of the notebooks take a few hours to run.  You'll need to schedule your notebooks to run as jobs.\n \n https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/schedule-task.html"
         },
         {
             "cell_type": "markdown",
@@ -253,7 +253,7 @@
         {
             "cell_type": "markdown",
             "metadata": {},
-            "source": "All data used in this notebook is the property of BackBlaze.com. \n\nFor questions regarding use of data please see the following website.\nhttps://www.backblaze.com/b2/hard-drive-test-data.html"
+            "source": "All data used in this notebook is the property of Backblaze. \n\nFor questions regarding use of data please see the following website.\nhttps://www.backblaze.com/b2/hard-drive-test-data.html"
         },
         {
             "cell_type": "code",

--- a/Backblaze -- Step 2 -- Mean Encoded Features.ipynb
+++ b/Backblaze -- Step 2 -- Mean Encoded Features.ipynb
@@ -3,7 +3,7 @@
         {
             "cell_type": "markdown",
             "metadata": {},
-            "source": "# A Complete Solution to the BackBaze.com Kaggle Problem"
+            "source": "# A Complete Solution to the Backblaze Kaggle Problem"
         },
         {
             "cell_type": "markdown",
@@ -28,7 +28,7 @@
         {
             "cell_type": "markdown",
             "metadata": {},
-            "source": "BackBaze.com, you are the \"GOAT.\" You are the \"cat's meow.\" You \"Rock the House.\" In case you don't know why BackBaze.com is so totally \"kick-ass,\" they open-sourced a vast set of hard drive information a few years ago and continue updating it each quarter. What a treasure trove of superb data. BackBlaze.com, thank you from the bottom of my heart. \n\nThe backblaze.com data includes operational metrics from hard drives with an indicator of a hard-drive failure. It is an excellent source for teaching techniques related to machine failure. Again, thank you for making this available to the open-source community.\n\nHere is a link to the data.\n\n\nhttps://www.backblaze.com/b2/hard-drive-test-data.html\n\nMy goal in this series of articles is not to give the best solution with the highest AUC.  My goal is to show you how to approach equipment failure problems and build solutions that reflect realistic accuracy, and provide an easy transition from the lab to the real world. \n\nI will use a Spark/Python Jupyter notebook inside IBM's Watson Studio on the cloud as a tool in this discussion.\n\nhttps://www.ibm.com/cloud/watson-studio\n\nI will also be using cloud object storage on the IBM cloud.\n\nhttps://www.ibm.com/cloud/block-storage\n\n\nThe third article is about designing features for a predictive model.  Specifically, using data from 2017, 2018 and 2019 to build features for our model based on 2020.  For more information on mean encoded features, please see the following article.\n\nhttps://medium.com/towards-data-science/leveraging-value-from-postal-codes-naics-codes-area-codes-and-other-funky-arse-categorical-be9ce75b6d5a\n\nI created these notebooks with a runtime useing 1 driver with 1 vCPU and 4 GB RAM, and 2 executors each with 1 vCPU and 4 GB RAM. This is available for free on the IBM Cloud. Some of the notebooks take a few hours to run. You'll need to schedule your notebooks to run as jobs.\n\nhttps://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/schedule-task.html"
+            "source": "Backblaze, you are the \"GOAT.\" You are the \"cat's meow.\" You \"Rock the House.\" In case you don't know why Backblaze is so totally \"kick-ass,\" they open-sourced a vast set of hard drive information a few years ago and continue updating it each quarter. What a treasure trove of superb data. Backblaze, thank you from the bottom of my heart. \n\nThe Backblaze data includes operational metrics from hard drives with an indicator of a hard-drive failure. It is an excellent source for teaching techniques related to machine failure. Again, thank you for making this available to the open-source community.\n\nHere is a link to the data.\n\n\nhttps://www.backblaze.com/b2/hard-drive-test-data.html\n\nMy goal in this series of articles is not to give the best solution with the highest AUC.  My goal is to show you how to approach equipment failure problems and build solutions that reflect realistic accuracy, and provide an easy transition from the lab to the real world. \n\nI will use a Spark/Python Jupyter notebook inside IBM's Watson Studio on the cloud as a tool in this discussion.\n\nhttps://www.ibm.com/cloud/watson-studio\n\nI will also be using cloud object storage on the IBM cloud.\n\nhttps://www.ibm.com/cloud/block-storage\n\n\nThe third article is about designing features for a predictive model.  Specifically, using data from 2017, 2018 and 2019 to build features for our model based on 2020.  For more information on mean encoded features, please see the following article.\n\nhttps://medium.com/towards-data-science/leveraging-value-from-postal-codes-naics-codes-area-codes-and-other-funky-arse-categorical-be9ce75b6d5a\n\nI created these notebooks with a runtime useing 1 driver with 1 vCPU and 4 GB RAM, and 2 executors each with 1 vCPU and 4 GB RAM. This is available for free on the IBM Cloud. Some of the notebooks take a few hours to run. You'll need to schedule your notebooks to run as jobs.\n\nhttps://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/schedule-task.html"
         },
         {
             "cell_type": "markdown",
@@ -266,7 +266,7 @@
         {
             "cell_type": "markdown",
             "metadata": {},
-            "source": "All data used in this notebook is the property of BackBlaze.com.\n\nFor questions regarding use of data please see the following website. https://www.backblaze.com/b2/hard-drive-test-data.html"
+            "source": "All data used in this notebook is the property of Backblaze.\n\nFor questions regarding use of data please see the following website. https://www.backblaze.com/b2/hard-drive-test-data.html"
         },
         {
             "cell_type": "code",

--- a/Backblaze -- Step 3 -- Shape and Clean.ipynb
+++ b/Backblaze -- Step 3 -- Shape and Clean.ipynb
@@ -3,7 +3,7 @@
         {
             "cell_type": "markdown",
             "metadata": {},
-            "source": "# A Complete Solution to the BackBaze.com Kaggle Problem"
+            "source": "# A Complete Solution to the Backblaze Kaggle Problem"
         },
         {
             "cell_type": "markdown",
@@ -28,7 +28,7 @@
         {
             "cell_type": "markdown",
             "metadata": {},
-            "source": "Note this is part two of a four-part solution.\n\nBackBlaze.com, you are the \"GOAT.\" You are the \"cat's meow.\" You \"Rock the House.\" In case you don't know why BackBaze.com is so totally \"kick-ass,\" they open-sourced a vast set of hard drive information a few years ago and continue updating it each quarter.  What a treasure trove of superb data.  BackBlaze.com, thank you from the bottom of my heart.\n\nThe backblaze.com data includes operational metrics from hard drives with an indicator of a hard-drive failure.  It is an excellent source for teaching techniques related to machine failure.  Again, thank you for making this available to the open-source community.\nHere is a link to the data.\n\nhttps://www.backblaze.com/b2/hard-drive-test-data.html\n\nMy goal in this series of articles is not to give the best solution with the highest AUC.  My goal is to show you how to approach equipment failure problems and build solutions that reflect realistic accuracy, and provide an easy transition from the lab to the real world.\n\nI will use a Spark/Python Jupyter notebook inside IBM's Watson Studio on the cloud as a tool in this discussion.\n\nhttps://www.ibm.com/cloud/watson-studio\n\nI will also be using cloud object storage on the IBM cloud.\n\nhttps://www.ibm.com/cloud/block-storage\n\n\nThe third article in this series is not very exciting but is critical.  I will be shaping and scoping the data set I created in the first article, so it is ready for machine learning.\n\nRarely is it a good idea to take the data as it comes.  It is almost always a good idea to shape your data to be consistent with the problem that needs solving.  The backblaze.com data is no different.  In this notebook, we will take the raw data and shape it to pass it to a machine-learning model.\n\nIn the first article of this series, we read the raw data from 2018,2019, and 2020.  Data from 2017, 2018, and 2019 are for creating features.  The 2020 data is for modeling.  Therefore, our shaping exercise is limited to 2020 data.\n"
+            "source": "Note this is part two of a four-part solution.\n\nBackblaze, you are the \"GOAT.\" You are the \"cat's meow.\" You \"Rock the House.\" In case you don't know why Backblaze is so totally \"kick-ass,\" they open-sourced a vast set of hard drive information a few years ago and continue updating it each quarter.  What a treasure trove of superb data.  Backblaze, thank you from the bottom of my heart.\n\nThe Backblaze data includes operational metrics from hard drives with an indicator of a hard-drive failure.  It is an excellent source for teaching techniques related to machine failure.  Again, thank you for making this available to the open-source community.\nHere is a link to the data.\n\nhttps://www.backblaze.com/b2/hard-drive-test-data.html\n\nMy goal in this series of articles is not to give the best solution with the highest AUC.  My goal is to show you how to approach equipment failure problems and build solutions that reflect realistic accuracy, and provide an easy transition from the lab to the real world.\n\nI will use a Spark/Python Jupyter notebook inside IBM's Watson Studio on the cloud as a tool in this discussion.\n\nhttps://www.ibm.com/cloud/watson-studio\n\nI will also be using cloud object storage on the IBM cloud.\n\nhttps://www.ibm.com/cloud/block-storage\n\n\nThe third article in this series is not very exciting but is critical.  I will be shaping and scoping the data set I created in the first article, so it is ready for machine learning.\n\nRarely is it a good idea to take the data as it comes.  It is almost always a good idea to shape your data to be consistent with the problem that needs solving.  The Backblaze data is no different.  In this notebook, we will take the raw data and shape it to pass it to a machine-learning model.\n\nIn the first article of this series, we read the raw data from 2018,2019, and 2020.  Data from 2017, 2018, and 2019 are for creating features.  The 2020 data is for modeling.  Therefore, our shaping exercise is limited to 2020 data.\n"
         },
         {
             "cell_type": "markdown",
@@ -438,7 +438,7 @@
         {
             "cell_type": "markdown",
             "metadata": {},
-            "source": "All data used in this notebook is the property of BackBlaze.com. \n\nFor questions regarding use of data please see the following website.\nhttps://www.backblaze.com/b2/hard-drive-test-data.html"
+            "source": "All data used in this notebook is the property of Backblaze. \n\nFor questions regarding use of data please see the following website.\nhttps://www.backblaze.com/b2/hard-drive-test-data.html"
         },
         {
             "cell_type": "code",

--- a/Backblaze -- Step 4 -- Adding Features.ipynb
+++ b/Backblaze -- Step 4 -- Adding Features.ipynb
@@ -3,7 +3,7 @@
         {
             "cell_type": "markdown",
             "metadata": {},
-            "source": "# A Complete Solution to the BackBaze.com Kaggle Problem"
+            "source": "# A Complete Solution to the Backblaze Kaggle Problem"
         },
         {
             "cell_type": "markdown",
@@ -28,7 +28,7 @@
         {
             "cell_type": "markdown",
             "metadata": {},
-            "source": "Note this is part two of a four-part solution.\n\nBackBlaze.com, you are the \"GOAT.\" You are the \"cat's meow.\" You \"Rock the House.\" In case you don't know why BackBaze.com is so totally \"kick-ass,\" they open-sourced a vast set of hard drive information a few years ago and continue updating it each quarter.  What a treasure trove of superb data.  BackBlaze.com, thank you from the bottom of my heart.\n\nThe backblaze.com data includes operational metrics from hard drives with an indicator of a hard-drive failure.  It is an excellent source for teaching techniques related to machine failure.  Again, thank you for making this available to the open-source community.\nHere is a link to the data.\n\nhttps://www.backblaze.com/b2/hard-drive-test-data.html\n\nMy goal in this series of articles is not to give the best solution with the highest AUC.  My goal is to show you how to approach equipment failure problems and build solutions that reflect realistic accuracy, and provide an easy transition from the lab to the real world.\n\nI will use a Spark/Python Jupyter notebook inside IBM's Watson Studio on the cloud as a tool in this discussion.\n\nhttps://www.ibm.com/cloud/watson-studio\n\nI will also be using cloud object storage on the IBM cloud.\n\nhttps://www.ibm.com/cloud/block-storage\n\n\nThe fourth article in this series we will create featues and append them to the data.  We will also append the features we created in Step Two. \n\nI created these notebooks with a runtime useing 1 driver with 1 vCPU and 4 GB RAM, and 2 executors each with 1 vCPU and 4 GB RAM. This is available for free on the IBM Cloud. Some of the notebooks take a few hours to run. You'll need to schedule your notebooks to run as jobs.\n\nhttps://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/schedule-task.html"
+            "source": "Note this is part two of a four-part solution.\n\nBackblaze, you are the \"GOAT.\" You are the \"cat's meow.\" You \"Rock the House.\" In case you don't know why Backblaze is so totally \"kick-ass,\" they open-sourced a vast set of hard drive information a few years ago and continue updating it each quarter.  What a treasure trove of superb data.  Backblaze, thank you from the bottom of my heart.\n\nThe Backblaze data includes operational metrics from hard drives with an indicator of a hard-drive failure.  It is an excellent source for teaching techniques related to machine failure.  Again, thank you for making this available to the open-source community.\nHere is a link to the data.\n\nhttps://www.backblaze.com/b2/hard-drive-test-data.html\n\nMy goal in this series of articles is not to give the best solution with the highest AUC.  My goal is to show you how to approach equipment failure problems and build solutions that reflect realistic accuracy, and provide an easy transition from the lab to the real world.\n\nI will use a Spark/Python Jupyter notebook inside IBM's Watson Studio on the cloud as a tool in this discussion.\n\nhttps://www.ibm.com/cloud/watson-studio\n\nI will also be using cloud object storage on the IBM cloud.\n\nhttps://www.ibm.com/cloud/block-storage\n\n\nThe fourth article in this series we will create featues and append them to the data.  We will also append the features we created in Step Two. \n\nI created these notebooks with a runtime useing 1 driver with 1 vCPU and 4 GB RAM, and 2 executors each with 1 vCPU and 4 GB RAM. This is available for free on the IBM Cloud. Some of the notebooks take a few hours to run. You'll need to schedule your notebooks to run as jobs.\n\nhttps://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/schedule-task.html"
         },
         {
             "cell_type": "markdown",
@@ -389,7 +389,7 @@
         {
             "cell_type": "markdown",
             "metadata": {},
-            "source": "All data used in this notebook is the property of BackBlaze.com.\n\nFor questions regarding use of data please see the following website. https://www.backblaze.com/b2/hard-drive-test-data.html"
+            "source": "All data used in this notebook is the property of Backblaze.\n\nFor questions regarding use of data please see the following website. https://www.backblaze.com/b2/hard-drive-test-data.html"
         },
         {
             "cell_type": "code",

--- a/Backblaze -- Step 5 -- Build model.ipynb
+++ b/Backblaze -- Step 5 -- Build model.ipynb
@@ -3,7 +3,7 @@
         {
             "cell_type": "markdown",
             "metadata": {},
-            "source": "# A Complete Solution to the BackBaze.com Kaggle Problem"
+            "source": "# A Complete Solution to the Backblaze Kaggle Problem"
         },
         {
             "cell_type": "markdown",
@@ -28,7 +28,7 @@
         {
             "cell_type": "markdown",
             "metadata": {},
-            "source": "Note this is part five of a six-part solution.\n\nBackBlaze.com, you are the \"GOAT.\" You are the \"cat's meow.\" You \"Rock the House.\" In case you don't know why BackBaze.com is so totally \"kick-ass,\" they open-sourced a vast set of hard drive information a few years ago and continue updating it each quarter.  What a treasure trove of superb data.  BackBlaze.com, thank you from the bottom of my heart.\n\nThe backblaze.com data includes operational metrics from hard drives with an indicator of a hard-drive failure.  It is an excellent source for teaching techniques related to machine failure.  Again, thank you for making this available to the open-source community.\nHere is a link to the data.\n\nhttps://www.backblaze.com/b2/hard-drive-test-data.html\n\nMy goal in this series of articles is not to give the best solution with the highest AUC.  My goal is to show you how to approach equipment failure problems and build solutions that reflect realistic accuracy, and provide an easy transition from the lab to the real world.\n\nI will use a Spark/Python Jupyter notebook inside IBM's Watson Studio on the cloud as a tool in this discussion.\n\nhttps://www.ibm.com/cloud/watson-studio\n\nI will also be using cloud object storage on the IBM cloud.\n\nhttps://www.ibm.com/cloud/block-storage\n\n\n\n"
+            "source": "Note this is part five of a six-part solution.\n\nBackblaze, you are the \"GOAT.\" You are the \"cat's meow.\" You \"Rock the House.\" In case you don't know why Backblaze is so totally \"kick-ass,\" they open-sourced a vast set of hard drive information a few years ago and continue updating it each quarter.  What a treasure trove of superb data.  Backblaze, thank you from the bottom of my heart.\n\nThe Backblaze data includes operational metrics from hard drives with an indicator of a hard-drive failure.  It is an excellent source for teaching techniques related to machine failure.  Again, thank you for making this available to the open-source community.\nHere is a link to the data.\n\nhttps://www.backblaze.com/b2/hard-drive-test-data.html\n\nMy goal in this series of articles is not to give the best solution with the highest AUC.  My goal is to show you how to approach equipment failure problems and build solutions that reflect realistic accuracy, and provide an easy transition from the lab to the real world.\n\nI will use a Spark/Python Jupyter notebook inside IBM's Watson Studio on the cloud as a tool in this discussion.\n\nhttps://www.ibm.com/cloud/watson-studio\n\nI will also be using cloud object storage on the IBM cloud.\n\nhttps://www.ibm.com/cloud/block-storage\n\n\n\n"
         },
         {
             "cell_type": "markdown",
@@ -786,7 +786,7 @@
         {
             "cell_type": "markdown",
             "metadata": {},
-            "source": "All data used in this notebook is the property of BackBlaze.com.\n\nFor questions regarding use of data please see the following website. https://www.backblaze.com/b2/hard-drive-test-data.html"
+            "source": "All data used in this notebook is the property of Backblaze.\n\nFor questions regarding use of data please see the following website. https://www.backblaze.com/b2/hard-drive-test-data.html"
         },
         {
             "cell_type": "code",

--- a/Backblaze -- Step 6 -- Evaluate Model.ipynb
+++ b/Backblaze -- Step 6 -- Evaluate Model.ipynb
@@ -3,7 +3,7 @@
         {
             "cell_type": "markdown",
             "metadata": {},
-            "source": "# A Complete Solution to the BackBaze.com Kaggle Problem"
+            "source": "# A Complete Solution to the Backblaze Kaggle Problem"
         },
         {
             "cell_type": "markdown",
@@ -28,7 +28,7 @@
         {
             "cell_type": "markdown",
             "metadata": {},
-            "source": "Note this is part six of a six-part solution.\n\nBackBlaze.com, you are the \"GOAT.\" You are the \"cat's meow.\" You \"Rock the House.\" In case you don't know why BackBaze.com is so totally \"kick-ass,\" they open-sourced a vast set of hard drive information a few years ago and continue updating it each quarter. What a treasure trove of superb data. BackBlaze.com, thank you from the bottom of my heart.\n\nThe backblaze.com data includes operational metrics from hard drives with an indicator of a hard-drive failure. It is an excellent source for teaching techniques related to machine failure. Again, thank you for making this available to the open-source community. Here is a link to the data.\n\nhttps://www.backblaze.com/b2/hard-drive-test-data.html\n\nMy goal in this series of articles is not to give the best solution with the highest AUC. My goal is to show you how to approach equipment failure problems and build solutions that reflect realistic accuracy, and provide an easy transition from the lab to the real world.\n\nI will use a Spark/Python Jupyter notebook inside IBM's Watson Studio on the cloud as a tool in this discussion.\n\nhttps://www.ibm.com/cloud/watson-studio\n\nI will also be using cloud object storage on the IBM cloud.\n\nhttps://www.ibm.com/cloud/block-storage\n\n"
+            "source": "Note this is part six of a six-part solution.\n\nBackblaze, you are the \"GOAT.\" You are the \"cat's meow.\" You \"Rock the House.\" In case you don't know why Backblaze is so totally \"kick-ass,\" they open-sourced a vast set of hard drive information a few years ago and continue updating it each quarter. What a treasure trove of superb data. Backblaze, thank you from the bottom of my heart.\n\nThe Backblaze data includes operational metrics from hard drives with an indicator of a hard-drive failure. It is an excellent source for teaching techniques related to machine failure. Again, thank you for making this available to the open-source community. Here is a link to the data.\n\nhttps://www.backblaze.com/b2/hard-drive-test-data.html\n\nMy goal in this series of articles is not to give the best solution with the highest AUC. My goal is to show you how to approach equipment failure problems and build solutions that reflect realistic accuracy, and provide an easy transition from the lab to the real world.\n\nI will use a Spark/Python Jupyter notebook inside IBM's Watson Studio on the cloud as a tool in this discussion.\n\nhttps://www.ibm.com/cloud/watson-studio\n\nI will also be using cloud object storage on the IBM cloud.\n\nhttps://www.ibm.com/cloud/block-storage\n\n"
         },
         {
             "cell_type": "markdown",
@@ -2666,7 +2666,7 @@
         {
             "cell_type": "markdown",
             "metadata": {},
-            "source": "All data used in this notebook is the property of BackBlaze.com.\n\nFor questions regarding use of data please see the following website. https://www.backblaze.com/b2/hard-drive-test-data.html\n\n"
+            "source": "All data used in this notebook is the property of Backblaze.\n\nFor questions regarding use of data please see the following website. https://www.backblaze.com/b2/hard-drive-test-data.html\n\n"
         }
     ],
     "metadata": {


### PR DESCRIPTION
Hi Shad - thank you so much for publishing your work here! Reading through it, I noticed a few typos in our company name, so I fixed those, and also removed the '.com' suffix where it wasn't part of a URL - we go by just 'Backblaze'. I also renamed the files with digits instead of words for the part numbers so that they are listed in numerical order.

I'm just embarking on some exploratory work with PyTorch and the Drive Stats data, so I'm sure our paths will cross again soon 🙂